### PR TITLE
Add macos-14 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-12, macos-13]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-12, macos-13, macos-14]
         node: [18, 20, 22]
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
Seems fitting since it is the latest macOS version and has been released since Sept 26, 2023.