### PR TITLE
Finish errant ESM upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       run: npm run lint
 
     - name: running test
-      run: npm run test
+      run: npm run test:dist
 
     - name: running codecov
       if: ${{ matrix.node == '20' && matrix.os == 'ubuntu-22.04' }}

--- a/package.json
+++ b/package.json
@@ -14,8 +14,9 @@
     "build": "node-gyp rebuild -v && npm run bundle",
     "download": "node ./download-libzim.js",
     "bundle": "node ./bundle-libzim.js",
-    "test": "jest",
+    "test": "jest --testPathIgnorePatterns=test/dist.test.ts",
     "test-mem-leak": "node -r ts-node/register test/makeLargeZim.ts",
+    "test:dist": "npm run build && jest",
     "lint": "npx eslint .",
     "lint:fix": "npx eslint . --fix"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import bindings from "bindings";
 
-const {
+export const {
   Archive,
   Entry,
   IntegrityCheck,
@@ -15,19 +15,3 @@ const {
   StringItem,
   FileItem,
 } = bindings("zim_binding");
-
-module.exports = {
-  Archive,
-  Entry,
-  IntegrityCheck,
-  Compression,
-  Blob,
-  Searcher,
-  Query,
-  SuggestionSearcher,
-  Creator,
-  StringProvider,
-  FileProvider,
-  StringItem,
-  FileItem,
-};

--- a/test/dist.test.ts
+++ b/test/dist.test.ts
@@ -1,0 +1,33 @@
+import {
+  Archive,
+  Entry,
+  IntegrityCheck,
+  Compression,
+  Blob,
+  Searcher,
+  Query,
+  SuggestionSearcher,
+  Creator,
+  StringProvider,
+  FileProvider,
+  StringItem,
+  FileItem,
+} from "../dist/index";
+
+describe("libzim dist", () => {
+  it("should have all the functions", () => {
+    expect(Archive).toBeDefined();
+    expect(Entry).toBeDefined();
+    expect(IntegrityCheck).toBeDefined();
+    expect(Compression).toBeDefined();
+    expect(Blob).toBeDefined();
+    expect(Searcher).toBeDefined();
+    expect(Query).toBeDefined();
+    expect(SuggestionSearcher).toBeDefined();
+    expect(Creator).toBeDefined();
+    expect(StringProvider).toBeDefined();
+    expect(FileProvider).toBeDefined();
+    expect(StringItem).toBeDefined();
+    expect(FileItem).toBeDefined();
+  });
+});


### PR DESCRIPTION
The ESM conversion was only partially complete in #136. The PR #141 updated it to use the right import syntax.

This PR further updates the index.js file to use the right **export** syntax for ESM.

Additionally, we add a "dist" test that imports from the finished dist/ folder. This ensures that everything is "hooked up" properly and that all the symbols can be properly imported.

This PR should be released immediately as 3.2.3, because the exports are broken in 3.2.2. (And maybe the changelog should reflect that 3.2.1 and 3.2.2 are faulty).

Sorry!