### PR TITLE
Multiple fixes on the CI/CD workflows

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,4 +1,4 @@
-name: Publish to npmjs.com
+name: CD
 
 on:
   release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-13, macos-14, macos-15]
+        os: [ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, macos-15]
         node: [18, 20, 22]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-12, macos-13, macos-14]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-13, macos-14]
         node: [18, 20, 22]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04, macos-13, macos-14]
+        os: [ubuntu-20.04, ubuntu-22.04, macos-13, macos-14, macos-15]
         node: [18, 20, 22]
     runs-on: ${{ matrix.os }}
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is the Node.js binding to the
 [ZIM](https://openzim.org) files easily in Javascript.
 
 [![npm](https://img.shields.io/npm/v/@openzim/libzim.svg)](https://www.npmjs.com/package/@openzim/libzim)
-[![Build Status](https://github.com/openzim/node-libzim/workflows/CI/badge.svg?branch=main)](https://github.com/openzim/node-libzim/actions?query=branch%3Amain)
+[![Build Status](https://github.com/openzim/node-libzim/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/openzim/node-libzim/actions/workflows/ci.yml?query=branch%3Amain)
 [![codecov](https://codecov.io/gh/openzim/node-libzim/branch/main/graph/badge.svg)](https://codecov.io/gh/openzim/node-libzim)
 [![CodeFactor](https://www.codefactor.io/repository/github/openzim/node-libzim/badge)](https://www.codefactor.io/repository/github/openzim/node-libzim)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)


### PR DESCRIPTION
* Remove macOS 12 from the CI because there is no runner provided anymore
* Rename CD workflow
* Add Ubuntu 24.04 and macOS 15 to the CI
* Fix CI `README.md` badge