### PR TITLE
feat(build): add arm64 and arm support for Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, macos-15]
+        os: [ubuntu-22.04, ubuntu-22.04-arm, ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-14, macos-15]
         node: [20, 22, 24]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,12 @@ jobs:
       with:
         node-version: ${{ matrix.node }}
 
-    - name: installing add on packages
+    - name: Update apt and install packages
       if: startsWith(matrix.os, 'ubuntu')
-      run: sudo apt install gcc g++ python3-pip libbz2-dev ccache zlib1g-dev uuid-dev
+      run: |
+        sudo apt-get update -y
+        sudo apt-get install -y \
+          gcc g++ python3-pip libbz2-dev ccache zlib1g-dev uuid-dev
 
     - name: Setup Python 3.11
       uses: actions/setup-python@v5

--- a/Changelog
+++ b/Changelog
@@ -1,4 +1,6 @@
 Unreleased
+* NEW: Build now supports ARM64 (`aarch64`) and ARM (32‑bit)
+* UPDATE: CI matrix extended with ARM64 Ubuntu runners
 
 3.4.0
 * NEW: Add new libzim 9.3.0 APIs around cache management

--- a/binding.gyp
+++ b/binding.gyp
@@ -11,13 +11,14 @@
                 "link_settings": {
                   "ldflags": [
                       "<!(pkg-config --libs-only-other --libs-only-L libzim)",
+                      "-Wl,-rpath,<!(pkg-config --variable=libdir libzim)>"
                   ],
                   "libraries": [
                       "<!(pkg-config --libs-only-l libzim)",
                   ],
                 },
               }],
-              ["libzim_local!='true' and OS=='linux'", {
+              ["libzim_local!='true' and OS=='linux' and target_arch=='x64'", {
                 "include_dirs": [
                   "<(libzim_include)",
                 ],
@@ -25,6 +26,26 @@
                   "-Wl,-rpath,'$$ORIGIN'",
                   "-L<(libzim_dir)/lib/x86_64-linux-gnu",
                   "<(libzim_dir)/lib/x86_64-linux-gnu/libzim.so.9",
+                ],
+              }],
+              ["libzim_local!='true' and OS=='linux' and target_arch=='arm64'", {
+                "include_dirs": [
+                  "<(libzim_include)",
+                ],
+                "libraries": [
+                  "-Wl,-rpath,'$$ORIGIN'",
+                  "-L<(libzim_dir)/lib/aarch64-linux-gnu",
+                  "<(libzim_dir)/lib/aarch64-linux-gnu/libzim.so.9",
+                ],
+              }],
+              ["libzim_local!='true' and OS=='linux' and target_arch=='arm'", {
+                "include_dirs": [
+                  "<(libzim_include)",
+                ],
+                "libraries": [
+                  "-Wl,-rpath,'$$ORIGIN'",
+                  "-L<(libzim_dir)/lib/arm-linux-gnueabihf",
+                  "<(libzim_dir)/lib/arm-linux-gnueabihf/libzim.so.9",
                 ],
               }],
               ["libzim_local!='true' and OS=='mac'", {

--- a/bundle-libzim.js
+++ b/bundle-libzim.js
@@ -16,11 +16,19 @@ if (!isMacOS && !isLinux) {
 }
 
 if (isLinux) {
-  console.info("Copying libzim.so.9 to build folder");
-  exec(
-    "cp download/lib/x86_64-linux-gnu/libzim.so.9 build/Release/libzim.so.9",
-  );
-  exec("ln -sf build/Release/libzim.so.9 build/Release/libzim.so"); // convienience only, not required
+  const rawArch = os.arch();
+  let libDir;
+  if (rawArch === "arm64") {
+    libDir = "aarch64-linux-gnu";
+  } else if (rawArch === "arm") {
+    libDir = "arm-linux-gnueabihf";
+  } else {
+    libDir = "x86_64-linux-gnu";
+  }
+
+  console.info(`Copying libzim.so.9 from ${libDir} to build folder`);
+  exec(`cp download/lib/${libDir}/libzim.so.9 build/Release/libzim.so.9`);
+  exec("ln -sf build/Release/libzim.so.9 build/Release/libzim.so"); // convenience only, not required
 }
 if (isMacOS) {
   console.info("Copying libzim.9.dylib to build folder");


### PR DESCRIPTION
The previous build process only supported `x86_64` on Linux, causing installation to fail on other architectures like `arm64` (aarch64) and `arm`. This commit makes the build system architecture-aware.

- `binding.gyp` is updated to use conditional logic based on `target_arch` to select the correct library path (`x86_64-linux-gnu`, `aarch64-linux-gnu`, or `arm-linux-gnueabihf`) for linking the native addon.

- `bundle-libzim.js` now detects the system architecture via `os.arch()` to ensure the correct shared library is copied into the final build directory.

Additionally, for local development builds (`--libzim_local=true`), the library's `rpath` is now added to the linker flags. This embeds the path in the compiled addon, resolving runtime linker errors without requiring the `LD_LIBRARY_PATH` environment variable.

## Example of Error on `arm64`

In the example below, you can see that while  `os.arch()` is `arm64`, and the correct binaries are download, the hard-coded `x86_64` is still used.

```text
npm error code 1
npm error path /usr/local/lib/node_modules/@openzim/libzim
npm error command failed
npm error command sh -c npm run download && node-gyp rebuild -v && npm run bundle
npm error > @openzim/libzim@3.4.0 download
npm error > node ./download-libzim.js
npm error
npm error os.type() is: Linux
npm error os.arch() is: arm64
npm error Downloading Libzim from:  https://download.openzim.org/release/libzim/libzim_linux-aarch64-manylinux-9.3.0.tar.gz
npm error Running Extract: [tar --strip-components 1 -xf ./download/libzim_linux-aarch64-manylinux-9.3.0.tar.gz -C ./download]
npm error Successfully downloaded and extracted file
npm error
npm error make: Entering directory '/usr/local/lib/node_modules/@openzim/libzim/build'
npm error   g++ -o Release/obj.target/zim_binding/src/module.o ../src/module.cc '-DNODE_GYP_MODULE_NAME=zim_binding' '-DUSING_UV_SHARED=1' '-DUSING_V8_SHARED=1' '-DV8_DEPRECATION_WARNINGS=1' '-D_GLIBCXX_U
SE_CXX11_ABI=1' '-D_FILE_OFFSET_BITS=64' '-D_LARGEFILE_SOURCE' '-D__STDC_FORMAT_MACROS' '-DOPENSSL_NO_PINSHARED' '-DOPENSSL_THREADS' '-DNAPI_CPP_EXCEPTIONS' '-DBUILDING_NODE_EXTENSION' -I/root/.cache/node
-gyp/22.17.0/include/node -I/root/.cache/node-gyp/22.17.0/src -I/root/.cache/node-gyp/22.17.0/deps/openssl/config -I/root/.cache/node-gyp/22.17.0/deps/openssl/openssl/include -I/root/.cache/node-gyp/22.17
.0/deps/uv/include -I/root/.cache/node-gyp/22.17.0/deps/zlib -I/root/.cache/node-gyp/22.17.0/deps/v8/include -I/usr/local/lib/node_modules/@openzim/libzim/node_modules/node-addon-api -I/usr/local/lib/node
_modules/@openzim/libzim/download/include  -fPIC -pthread -Wall -Wextra -Wno-unused-parameter -O3 -fno-omit-frame-pointer -fno-rtti -fno-strict-aliasing -std=gnu++17 -std=c++17 -fexceptions -MMD -MF ./Rel
ease/.deps/Release/obj.target/zim_binding/src/module.o.d.raw   -c
npm error   g++ -o Release/obj.target/zim_binding.node -shared -pthread -rdynamic  -Wl,-soname=zim_binding.node -Wl,--start-group Release/obj.target/zim_binding/src/module.o -Wl,--end-group -Wl,-rpath,'$O
RIGIN' -L/usr/local/lib/node_modules/@openzim/libzim/download/lib/x86_64-linux-gnu /usr/local/lib/node_modules/@openzim/libzim/download/lib/x86_64-linux-gnu/libzim.so.9
npm error make: Leaving directory '/usr/local/lib/node_modules/@openzim/libzim/build'
```
## Testing

Below are the results of an install, rebuild and `npm test` after the changes have been applied.

```bash
$ npm install --ignore-scripts

up to date, audited 617 packages in 1s

85 packages are looking for funding
  run `npm fund` for details

2 vulnerabilities (1 low, 1 moderate)

To address all issues, run:
  npm audit fix

Run `npm audit` for details.
$ 
```

```bash
$ npx node-gyp rebuild --libzim_local=true
gyp info it worked if it ends with ok
gyp info using node-gyp@10.1.0
gyp info using node@22.17.0 | linux | arm64
gyp info find Python using Python version 3.11.2 found at "/usr/bin/python3"

gyp info spawn /usr/bin/python3
gyp info spawn args [
gyp info spawn args '/opt/pierow2k/node_modules/node-gyp/gyp/gyp_main.py',
gyp info spawn args 'binding.gyp',
gyp info spawn args '-f',
gyp info spawn args 'make',
gyp info spawn args '-I',
gyp info spawn args '/opt/pierow2k/build/config.gypi',
gyp info spawn args '-I',
gyp info spawn args '/opt/pierow2k/node_modules/node-gyp/addon.gypi',
gyp info spawn args '-I',
gyp info spawn args '/root/.cache/node-gyp/22.17.0/include/node/common.gypi',
gyp info spawn args '-Dlibrary=shared_library',
gyp info spawn args '-Dvisibility=default',
gyp info spawn args '-Dnode_root_dir=/root/.cache/node-gyp/22.17.0',
gyp info spawn args '-Dnode_gyp_dir=/opt/pierow2k/node_modules/node-gyp',
gyp info spawn args '-Dnode_lib_file=/root/.cache/node-gyp/22.17.0/<(target_arch)/node.lib',
gyp info spawn args '-Dmodule_root_dir=/opt/pierow2k',
gyp info spawn args '-Dnode_engine=v8',
gyp info spawn args '--depth=.',
gyp info spawn args '--no-parallel',
gyp info spawn args '--generator-output',
gyp info spawn args 'build',
gyp info spawn args '-Goutput_dir=.'
gyp info spawn args ]
gyp info spawn make
gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
make: Entering directory '/opt/pierow2k/build'
  CXX(target) Release/obj.target/zim_binding/src/module.o
  SOLINK_MODULE(target) Release/obj.target/zim_binding.node
  COPY Release/zim_binding.node
make: Leaving directory '/opt/pierow2k/build'
gyp info ok
$
```

```bash
$ npm test

> @openzim/libzim@3.4.1-dev0 test
> jest --testPathIgnorePatterns=test/dist.test.ts


 RUNS  test/zim.test.ts
Resolve redirect
 RUNS  test/zim.test.ts
Resolve redirect
 RUNS  test/zim.test.ts
 PASS  test/zim.test.ts
  IntegrityCheck
    ✓ is exported with symbols (2 ms)
  Compression
    ✓ is exported with symbols
  Blob
    ✓ constructs a blob
    ✓ returns proper data (1 ms)
  StringItem
    ✓ constructs a StringItem with proper data (2 ms)
    ✓ constructs a StringItem from a Buffer (1 ms)
  Creator
    ✓ Configures (1 ms)
    ✓ Creates a zim file (78 ms)
  Archive
    ✓ Validates an archive (4 ms)
    ✓ Reads items from an archive (26 ms)
    ✓ verifies that blobs were stored / read to / from the archive correctly (2 ms)
    ✓ verifies that blobs containing and ending in null were stored correctly from the archive (2 ms)
    Searcher
      ✓ searches the archive (2 ms)
    Suggestion Search
      ✓ searches for suggestions in the archive (2 ms)
    Cache sizes
      ✓ Manipulate cluster cache max size (1 ms)
      ✓ Manipulate dirent cache max size
      ✓ Manipulate dirent lookup cache max size (1 ms)
  Query
    ✓ constructs a query (1 ms)

Test Suites: 1 passed, 1 total
Tests:       18 passed, 18 total
Snapshots:   0 total
Time:        1.158 s
Ran all test suites.
$
```